### PR TITLE
Make the Charged Shot use destscale instead of scale

### DIFF
--- a/src/Lua/rsr/base/utilities.lua
+++ b/src/Lua/rsr/base/utilities.lua
@@ -151,6 +151,7 @@ RSR.ReflectMissile = function(source, oldMissile, newMissile)
 	newMissile.rsrProjectile = oldMissile.rsrProjectile
 	newMissile.rsrDamage = oldMissile.rsrDamage
 	newMissile.rsrRealDamage = oldMissile.rsrRealDamage
+	newMissile.rsrOrigScale = oldMissile.rsrOrigScale
 
 	-- Fixes a bug where the killfeed uses the placeholder Eggman icon
 	-- if a player with a Force Shield was killed

--- a/src/Lua/rsr/weapon/main/basic.lua
+++ b/src/Lua/rsr/weapon/main/basic.lua
@@ -199,7 +199,9 @@ RSR.SpawnBasicAlt = function(player, rsrinfo, chargeSound)
 	local missile = RSR.SpawnPlayerMissile(player.mo, MT_RSR_PROJECTILE_BASIC_CHARGED, player.mo.angle, player.cmd.aiming<<16, nil, 90*FRACUNIT + addChargeSpeed, altSound)
 	if Valid(missile) then
 		if rsrinfo.basicCharge >= 35 then missile.rsrChargeTravelSound = true end
-		missile.scale = FixedMul($, FRACUNIT/2 + addScale)
+		missile.rsrOrigScale = missile.scale
+		missile.scalespeed = missile.scale/4
+		missile.destscale = FixedMul(missile.scale, FRACUNIT/2 + addScale)
 		missile.rsrDamage = 20 + addDamage
 	end
 


### PR DESCRIPTION
Makes the Charged Shot cooperate better when the player is close to a wall.

Also makes RSR.ReflectMissile transfer the `rsrOrigScale` variable when making a duplicate of the old projectile.