### PR TITLE
Add rsr_killfeed cvar for toggling the killfeed

### DIFF
--- a/src/Lua/rsr/cvars.lua
+++ b/src/Lua/rsr/cvars.lua
@@ -1,11 +1,15 @@
 -- Ringslinger Revolution - Console Variables/Commands
 
+-- --------------------------------
+-- CLIENT CVARS
+-- --------------------------------
+
 RSR.CVVIEWMODEL_NONE = 0
 RSR.CVVIEWMODEL_RIGHT = 1
 RSR.CVVIEWMODEL_LEFT = 2
 RSR.CVVIEWMODEL_CENTER = 3
 
--- Lets homing rings target and kill spectators
+-- Lets the player set their viewmodel's orientation.
 RSR.CV_Viewmodel = CV_RegisterVar({
 	name = "rsr_viewmodel",
 	defaultvalue = "Right",
@@ -18,7 +22,7 @@ RSR.CV_Viewmodel = CV_RegisterVar({
 	}
 })
 
--- Lets homing rings target and kill spectators
+-- Lets the second player set their viewmodel's orientation.
 RSR.CV_Viewmodel2 = CV_RegisterVar({
 	name = "rsr_viewmodel2",
 	defaultvalue = "Right",
@@ -31,7 +35,29 @@ RSR.CV_Viewmodel2 = CV_RegisterVar({
 	}
 })
 
--- Lets homing rings target and kill spectators
+RSR.CVKILLFEED_NONE = 0
+RSR.CVKILLFEED_TEXT = 1
+RSR.CVKILLFEED_ICON = 2
+RSR.CVKILLFEED_BOTH = 3 -- Should be the previous two combined
+
+-- Lets the player set how the killfeed should be displayed.
+RSR.CV_Killfeed = CV_RegisterVar({
+	name = "rsr_killfeed",
+	defaultvalue = "Both",
+	flags = CV_SAVE,
+	PossibleValue = {
+		Off = RSR.CVKILLFEED_NONE,
+		Text = RSR.CVKILLFEED_TEXT,
+		Icon = RSR.CVKILLFEED_ICON,
+		Both = RSR.CVKILLFEED_BOTH
+	}
+})
+
+-- --------------------------------
+-- SERVER CVARS
+-- --------------------------------
+
+-- Lets homing rings target and kill spectators.
 RSR.CV_Ghostbusters = CV_RegisterVar({
 	name = "rsr_ghostbusters",
 	defaultvalue = "False",
@@ -39,13 +65,17 @@ RSR.CV_Ghostbusters = CV_RegisterVar({
 	PossibleValue = CV_TrueFalse
 })
 
--- Lets non-IT players use weapons in Tag
+-- Lets non-IT players use weapons in Tag.
 RSR.CV_LaserTag = CV_RegisterVar({
 	name = "rsr_lasertag",
 	defaultvalue = "True",
 	flags = CV_NETVAR|CV_SHOWMODIF,
 	PossibleValue = CV_TrueFalse
 })
+
+-- --------------------------------
+-- COMMANDS
+-- --------------------------------
 
 --- Checks if the player can use any of the kill commands.
 ---@param player player_t

--- a/src/Lua/rsr/hud/killfeed.lua
+++ b/src/Lua/rsr/hud/killfeed.lua
@@ -168,13 +168,14 @@ end
 ---@param obituary string|nil Default is "$v died.".
 ---@param distance fixed_t|nil Distance between the victim and their attacker. Default is 0.
 RSR.KillfeedPrint = function(victimName, attackerName, inflictorPatch, infReflected, highlight, skincolor, obituary, distance)
+	if RSR.CV_Killfeed.value == RSR.CVKILLFEED_NONE then return end -- Don't display a message if the killfeed is disabled
 	if not victimName then return end -- We can't display a message if there is no victim!
 	inflictorPatch = $ or "RSREGGM" -- Always show Eggman for unknown causes of death
 	obituary = $ or "$v died." -- Default message
 	distance = ($ or 0)/(56*FRACUNIT)
 	if distance >= 10 then obituary = $.." ("..distance.."m)" end
 
-	if CV_FindVar("hazardlog").value then
+	if (RSR.CV_Killfeed.value & RSR.CVKILLFEED_TEXT) then
 		-- Alternative killfeed so players can see what they did in the logs
 		local newString = string.gsub(obituary, "(%$%w?)", {
 			["$a"] = attackerName or "The Shredded Cheese Man",
@@ -184,16 +185,18 @@ RSR.KillfeedPrint = function(victimName, attackerName, inflictorPatch, infReflec
 		print(newString)
 	end
 
-	table.insert(RSR.KILLFEED_MESSAGES, {
-		victim = victimName,
-		inflictor = inflictorPatch,
-		infReflected = infReflected,
-		attacker = attackerName,
-		highlight = highlight,
-		skincolor = skincolor,
-		distance = distance,
-		tics = RSR.KILLFEED_TICS
-	})
+	if (RSR.CV_Killfeed.value & RSR.CVKILLFEED_ICON) then
+		table.insert(RSR.KILLFEED_MESSAGES, {
+			victim = victimName,
+			inflictor = inflictorPatch,
+			infReflected = infReflected,
+			attacker = attackerName,
+			highlight = highlight,
+			skincolor = skincolor,
+			distance = distance,
+			tics = RSR.KILLFEED_TICS
+		})
+	end
 end
 
 --- Gets the necessary damagetype-related info for killfeed varaibles.


### PR DESCRIPTION
There are four different options:
- 0/Off = Neither killfeed
- 1/Text = Text-based killfeed
- 2/Icon = Icon-based killfeed
- 3/Both = Both killfeeds

This PR also fixes the descriptions for `rsr_viewmodel` and `rsr_viewmodel2`.